### PR TITLE
Support multiple exclusion options

### DIFF
--- a/lib/fastlane/plugin/synx/actions/synx_action.rb
+++ b/lib/fastlane/plugin/synx/actions/synx_action.rb
@@ -15,8 +15,9 @@ module Fastlane
         cmd << ["--no-sort-by-name"] if params[:no_sort_by_name]
         cmd << ["--quiet"] if params[:quiet]
         if params[:exclusion]
-          Array(params[:exclusion]).each {|exclusion|
-            cmd.concat ["--exclusion", exclusion] }
+          Array(params[:exclusion]).each do |exclusion|
+            cmd.concat ["--exclusion", exclusion]
+          end
         end
         cmd << [project_name]
         Actions.sh(Shellwords.join(cmd))

--- a/lib/fastlane/plugin/synx/actions/synx_action.rb
+++ b/lib/fastlane/plugin/synx/actions/synx_action.rb
@@ -16,7 +16,7 @@ module Fastlane
         cmd << ["--quiet"] if params[:quiet]
         if params[:exclusion]
           Array(params[:exclusion]).each {|exclusion|
-            cmd << ["--exclusion #{exclusion}"] }
+            cmd.concat ["--exclusion", exclusion] }
         end
         cmd << [project_name]
         Actions.sh(Shellwords.join(cmd))

--- a/lib/fastlane/plugin/synx/actions/synx_action.rb
+++ b/lib/fastlane/plugin/synx/actions/synx_action.rb
@@ -12,7 +12,10 @@ module Fastlane
         cmd << ["--no-default-exclusions"] if params[:no_default_exclusions]
         cmd << ["--no-sort-by-name"] if params[:no_sort_by_name]
         cmd << ["--quiet"] if params[:quiet]
-        cmd << ["--exclusion #{params[:exclusion]}"] if params[:exclusion]
+        if params[:exclusion]
+          Array(params[:exclusion]).each {|exclusion|
+            cmd << ["--exclusion #{exclusion}"] }
+        end
         cmd << [project_name]
         Actions.sh(cmd.join(" "))
       end
@@ -65,7 +68,7 @@ module Fastlane
                                        env_name: "FL_SYNX_EXCLUSION",
                                        description: "Ignore an Xcode group while syncing",
                                        optional: true,
-                                       is_string: true,
+                                       is_string: false,
                                        default_value: nil)
         ]
       end

--- a/lib/fastlane/plugin/synx/actions/synx_action.rb
+++ b/lib/fastlane/plugin/synx/actions/synx_action.rb
@@ -2,6 +2,8 @@ module Fastlane
   module Actions
     class SynxAction < Action
       def self.run(params)
+        require 'shellwords'
+
         Actions.verify_gem!("synx")
 
         project_name = Dir["*.xcodeproj"].first
@@ -17,7 +19,7 @@ module Fastlane
             cmd << ["--exclusion #{exclusion}"] }
         end
         cmd << [project_name]
-        Actions.sh(cmd.join(" "))
+        Actions.sh(Shellwords.join(cmd))
       end
 
       def self.description

--- a/lib/fastlane/plugin/synx/version.rb
+++ b/lib/fastlane/plugin/synx/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Synx
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
I fixed issue  #2.

Multiple exclusion options are not support by environment variable.
Please review this.

_code example:_
```ruby
lane :run_synx do
   synx exclusion: 'Foo'
  synx exclusion: ['Foo', 'Bar']
end
```
